### PR TITLE
Add time unit

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -62,6 +62,16 @@ Code block 'Inner' took: 2.382 ms
 Code block 'Outer' took: 10.466 ms
 ```
 
+To get time in a different unit, you can do this:
+```
+with CodeTimer('Block', unit='h'):
+   slow_function()
+   
+Code block 'Block' took: 2.382 h
+```
+
+Supported units are ms, s , m, h corresponding to milliseconds, seconds, minutes, hours.
+
 If you need to **retain the time taken**, you can do it with:
 ```
 ct = CodeTimer()
@@ -69,7 +79,7 @@ ct = CodeTimer()
 with ct:
    slow_function()
    
-ct.took # This contains the # of milliseconds
+ct.took # This contains the time taken as per the unit provided (milliseconds by default)
 ```
 
 Finally, if you need to **turn off the printed statements**, use the `silent=False` argument

--- a/linetimer/__init__.py
+++ b/linetimer/__init__.py
@@ -1,24 +1,25 @@
 import timeit
 
+
 class CodeTimer:
 
     def __init__(self, name=None, silent=False):
-        '''Allows giving indented blocks their own name. Blank by default'''
+        """Allows giving indented blocks their own name. Blank by default"""
         self.name = name
         self.silent = silent
-        
+
     def __enter__(self):
-        '''Start measuring at the start of indent'''
+        """Start measuring at the start of indent"""
         self.start = timeit.default_timer()
 
     def __exit__(self, exc_type, exc_value, traceback):
-        '''
-            Stop measuring at the end of indent. This will run even 
+        """
+            Stop measuring at the end of indent. This will run even
             if the indented lines raise an exception.
-        '''
+        """
         self.took = (timeit.default_timer() - self.start) * 1000.0
-        
+
         if not self.silent:
-            print('Code block' + 
-                  (" '"  + str(self.name) + "'" if self.name else '') + 
+            print('Code block' +
+                  (" '" + str(self.name) + "'" if self.name else '') +
                   ' took: ' + str(self.took) + ' ms')

--- a/linetimer/__init__.py
+++ b/linetimer/__init__.py
@@ -1,12 +1,15 @@
 import timeit
 
+time_units = {'ms': 1, 's': 1000, 'm': 60 * 1000, 'h': 3600 * 1000}
+
 
 class CodeTimer:
 
-    def __init__(self, name=None, silent=False):
+    def __init__(self, name=None, silent=False, unit='ms'):
         """Allows giving indented blocks their own name. Blank by default"""
         self.name = name
         self.silent = silent
+        self.unit = unit
 
     def __enter__(self):
         """Start measuring at the start of indent"""
@@ -18,8 +21,11 @@ class CodeTimer:
             if the indented lines raise an exception.
         """
         self.took = (timeit.default_timer() - self.start) * 1000.0
+        self.took = self.took / time_units.get(self.unit, time_units['ms'])
 
         if not self.silent:
-            print('Code block' +
-                  (" '" + str(self.name) + "'" if self.name else '') +
-                  ' took: ' + str(self.took) + ' ms')
+            print('Code block{}took: {:.5f} {}'.format(
+                str(" '" + self.name + "' ") if self.name else ' ',
+                float(self.took),
+                str(self.unit))
+            )

--- a/tests/test_CodeTimer.py
+++ b/tests/test_CodeTimer.py
@@ -70,3 +70,27 @@ def test_two_nested():
 
     assert ct2.took >= 2000.0
     assert ct2.name == name2
+
+
+def test_time_unit():
+    from linetimer import CodeTimer
+
+    unit1 = 's'
+
+    ct1 = CodeTimer('ct_' + unit1, unit=unit1)
+
+    with ct1:
+        sleep(1)
+
+    assert ct1.took >= 1
+    assert ct1.unit == unit1
+
+    unit2 = 'xyz'
+
+    ct2 = CodeTimer('ct_' + unit2, unit=unit2)
+
+    with ct2:
+        sleep(1)
+
+    assert ct2.took >= 1000
+    assert ct2.unit == unit2

--- a/tests/test_CodeTimer.py
+++ b/tests/test_CodeTimer.py
@@ -1,5 +1,6 @@
 from time import sleep
 
+
 def test_single_blank():
     from linetimer import CodeTimer
 
@@ -46,6 +47,7 @@ def test_two_named():
 
     assert ct2.took >= 2000.0
     assert ct2.name == name2
+
 
 def test_two_nested():
     from linetimer import CodeTimer


### PR DESCRIPTION
This PR fixes #2 

> To get time in a different unit, you can do this:
> 
> ```
> with CodeTimer('Block', unit='h'):
>    slow_function()
> ```
>    
> Code block 'Block' took: 2.382 h
> Supported units are ms, s , m, h corresponding to milliseconds, seconds, minutes, hours.

Noted Changes:

1. Added time unit specification as shown above along with some tests

1. Code formatting as per PEP8
