### PR TITLE
Allow external loggers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+.idea

--- a/Readme.md
+++ b/Readme.md
@@ -90,8 +90,8 @@ my_logger = logging.get_logger('xyz')
 with CodeTimer('Block', unit='h', logger_func = my_logger.info):
    slow_function()
 ```
-This will result in,
-```   
+This will log to an appropriate handler,
+```
 INFO - Code block 'Block' took: 2.382 h
 ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -82,6 +82,19 @@ with ct:
 ct.took # This contains the time taken as per the unit provided (milliseconds by default)
 ```
 
+Sometimes you want to **use your own dedicated logger**, you can do it with:
+```
+import logging
+my_logger = logging.get_logger('xyz')
+
+with CodeTimer('Block', unit='h', logger_func = my_logger.info):
+   slow_function()
+```
+This will result in,
+```   
+INFO - Code block 'Block' took: 2.382 h
+```
+
 Finally, if you need to **turn off the printed statements**, use the `silent=True` argument
 
 ```

--- a/linetimer/__init__.py
+++ b/linetimer/__init__.py
@@ -5,11 +5,12 @@ time_units = {'ms': 1, 's': 1000, 'm': 60 * 1000, 'h': 3600 * 1000}
 
 class CodeTimer:
 
-    def __init__(self, name=None, silent=False, unit='ms'):
+    def __init__(self, name=None, silent=False, unit='ms', logger_func=None):
         """Allows giving indented blocks their own name. Blank by default"""
         self.name = name
         self.silent = silent
         self.unit = unit
+        self.logger_func = logger_func
 
     def __enter__(self):
         """Start measuring at the start of indent"""
@@ -24,8 +25,9 @@ class CodeTimer:
         self.took = self.took / time_units.get(self.unit, time_units['ms'])
 
         if not self.silent:
-            print('Code block{}took: {:.5f} {}'.format(
+            log_str = 'Code block{}took: {:.5f} {}'.format(
                 str(" '" + self.name + "' ") if self.name else ' ',
                 float(self.took),
                 str(self.unit))
-            )
+
+            self.logger_func(log_str) if self.logger_func else print(log_str)

--- a/linetimer/__init__.py
+++ b/linetimer/__init__.py
@@ -30,4 +30,7 @@ class CodeTimer:
                 float(self.took),
                 str(self.unit))
 
-            self.logger_func(log_str) if self.logger_func else print(log_str)
+            if self.logger_func:
+                self.logger_func(log_str)
+            else:
+                print(log_str)

--- a/tests/test_CodeTimer.py
+++ b/tests/test_CodeTimer.py
@@ -94,3 +94,44 @@ def test_time_unit():
 
     assert ct2.took >= 1000
     assert ct2.unit == unit2
+
+
+def test_logger_func(capsys):
+    import logging.config
+    from linetimer import CodeTimer
+
+    logger_config = {
+        'version': 1,
+        'disable_existing_loggers': False,
+        'formatters': {
+            'standard': {
+                'format': '[%(levelname)s] - %(message)s'
+            },
+        },
+        'handlers': {
+            'default': {
+                'level': 'INFO',
+                'formatter': 'standard',
+                'class': 'logging.StreamHandler',
+                'stream': 'ext://sys.stdout',  # Default is stderr
+            },
+        },
+        'loggers': {
+            '': {  # root logger
+                'handlers': ['default'],
+                'level': 'INFO',
+                'propagate': True
+            }
+        }
+    }
+
+    logging.config.dictConfig(logger_config)
+
+    logger = logging.getLogger()
+
+    with CodeTimer('ct', unit='s', logger_func=logger.info):
+        sleep(1)
+
+    captured = capsys.readouterr()
+    assert captured.out.startswith("[INFO] - Code block 'ct' took: 1")
+    assert captured.out.endswith(' s\n')


### PR DESCRIPTION
This PR fixes #4 

> import logging
> my_logger = logging.get_logger('xyz')
> 
> with CodeTimer('Block', unit='h', logger_func = my_logger.info):
>    slow_function()
> Corresponding to this, the output string has to be changed, for example,
> 
> 2019-07-02 14:24:42,807 - INFO - Code block 'Block' took: 2.382 h

Noted Changes:

- Added ability to pass external logger as parameter along with with test cases
